### PR TITLE
Changing the redirect_uri to localhost:3000 instead of 127.0.0.1:3000

### DIFF
--- a/auth-server/src/main/java/com/example/authserver/config/AuthorizationServerConfig.java
+++ b/auth-server/src/main/java/com/example/authserver/config/AuthorizationServerConfig.java
@@ -38,6 +38,10 @@ public class AuthorizationServerConfig {
   // http://localhost:8080/oauth2/authorize?response_type=code&client_id=client&scope=openid&redirect_uri=http://127.0.0.1:3000/authorized&code_challenge=QYPAZ5NU8yvtlQ9erXrUYR-T5AGCjCF47vN-KsaI2A8&code_challenge_method=S256
   // http://localhost:8080/oauth2/token?client_id=client&redirect_uri=http://127.0.0.1:3000/authorized&grant_type=authorization_code&code=MJ5WmUiOAnVFHi9BS6PS5dqHvO56fHkQVqR8gUg-yOmpgohvsFmH4xU6lFcwwDN0nkAcYdldOROnhAhf0cDROu-PgSup94fx28geM4p08TSEZ_c9c9vkL_yy34WBfnyY&code_verifier=qPsH306-ZDDaOE8DFzVn05TkN3ZZoVmI_6x4LsVglQI
 
+  // redirect_uri changed to localhost:
+  // http://localhost:8080/oauth2/authorize?response_type=code&client_id=client&scope=openid&redirect_uri=http://localhost:3000/authorized&code_challenge=QYPAZ5NU8yvtlQ9erXrUYR-T5AGCjCF47vN-KsaI2A8&code_challenge_method=S256
+  // http://localhost:8080/oauth2/token?client_id=client&redirect_uri=http://localhost:3000/authorized&grant_type=authorization_code&code=MJ5WmUiOAnVFHi9BS6PS5dqHvO56fHkQVqR8gUg-yOmpgohvsFmH4xU6lFcwwDN0nkAcYdldOROnhAhf0cDROu-PgSup94fx28geM4p08TSEZ_c9c9vkL_yy34WBfnyY&code_verifier=qPsH306-ZDDaOE8DFzVn05TkN3ZZoVmI_6x4LsVglQI // 
+  
   private final CORSCustomizer corsCustomizer;
 
   @Bean
@@ -59,7 +63,7 @@ public class AuthorizationServerConfig {
         .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
         .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
         .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-        .redirectUri("http://127.0.0.1:3000/authorized")
+        .redirectUri("http://localhost:3000/authorized") /// 127.0.0.1 changed to localhost
         .scope(OidcScopes.OPENID)
         .clientSettings(ClientSettings.builder()
             .requireAuthorizationConsent(true).build())

--- a/auth-server/src/main/java/com/example/authserver/config/CORSCustomizer.java
+++ b/auth-server/src/main/java/com/example/authserver/config/CORSCustomizer.java
@@ -15,8 +15,8 @@ public class CORSCustomizer {
       CorsConfigurationSource source = s -> {
         CorsConfiguration cc = new CorsConfiguration();
         cc.setAllowCredentials(true);
-        cc.setAllowedOrigins(List.of("http://127.0.0.1:3000"));
-        cc.setAllowedHeaders(List.of("*"));
+        cc.setAllowedOrigins(List.of("http://localhost:3000","http://127.0.0.1:3000")); /// Add Both localhost and 127.0.0.1 to CORS
+        c.setAllowedHeaders(List.of("*"));
         cc.setAllowedMethods(List.of("*"));
         return cc;
       };

--- a/oauth2_react/src/components/Redirect.js
+++ b/oauth2_react/src/components/Redirect.js
@@ -17,7 +17,7 @@ const Redirect = () => {
 
             const verifier = sessionStorage.getItem('codeVerifier');
             
-            const initialUrl = 'http://localhost:8080/oauth2/token?client_id=client&redirect_uri=http://127.0.0.1:3000/authorized&grant_type=authorization_code';
+            const initialUrl = 'http://localhost:8080/oauth2/token?client_id=client&redirect_uri=http://localhost:3000/authorized&grant_type=authorization_code';
             const url = `${initialUrl}&code=${code}&code_verifier=${verifier}`;
 
             fetch(url, {
@@ -38,7 +38,7 @@ const Redirect = () => {
     useEffect(() => {
         if(!searchParams?.get('code')){
             const codeChallenge = sessionStorage.getItem('codeChallenge');
-            const link = `http://localhost:8080/oauth2/authorize?response_type=code&client_id=client&scope=openid&redirect_uri=http://127.0.0.1:3000/authorized&code_challenge=${codeChallenge}&code_challenge_method=S256`;
+            const link = `http://localhost:8080/oauth2/authorize?response_type=code&client_id=client&scope=openid&redirect_uri=http://localhost:3000/authorized&code_challenge=${codeChallenge}&code_challenge_method=S256`;
           
             window.location.href = link;
         }


### PR DESCRIPTION
Dear Mr. Spilca thank you so much for the very useful tutorials you make on youtube.
The unreasonable problem of the "code_verifier" being null, originates from the address of the "redirect_uri". If you notice, when the authorization code is sent back to the browser,  the "redirect_uri" which is called is 127.0.0.1:3000, while the react project runs on localhost:3000 and the content of the "sessionStorage" are not accessible at the 127.0.0.1:3000 rather are accessible at localhost:3000. That's why we get an "code_verifier" with a null value.
To solve this strange and unreasonable problem, change the "redirect_uri" to localhost:3000 at the both back-end and front-end. And to avoid CORS errors, add the both addresses(127.0.0.1:3000 and localhost:3000) to the CORS configuration.